### PR TITLE
feat: pnpm

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -18,8 +18,11 @@ RUN apt-get install -y python3-pip golang
 RUN curl -fsSL https://deb.nodesource.com/setup_21.x | sudo -E bash - &&\
 sudo apt-get install -y nodejs
 
-# # Install Hardhat
-RUN npm install -g hardhat
+# # Install PNPM
+RUN npm install -g pnpm
+
+# # Install hardhat
+RUN pnpm install hardhat
 
 # Install solc-select
 RUN pip3 install solc-select

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ volume.
 - frameworks: hardhat, foundry
 - utilities: solc-select
 - fuzzing: slither, medusa
-- others: node, npm, python, go
+- others: node, pnpm, python, go
 - terminal: fish with starship theme
 - extensions:
    - `NomicFoundation.hardhat-solidity`,


### PR DESCRIPTION
Installs pnpm, the new alternative to npm commonly used by top Solidity protocols like https://github.com/ethereum-optimism/optimism.