### PR TITLE
Fix medusa installation using multi-stage build

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,17 @@
+###
+### Medusa build stage
+###
+FROM golang:1.22 AS medusa
+
+WORKDIR /src
+RUN git clone https://github.com/crytic/medusa.git
+RUN cd medusa && \
+    go build -trimpath -o=/usr/local/bin/medusa -ldflags="-s -w" && \
+    chmod 755 /usr/local/bin/medusa
+
+###
+### Devcontainer build stage
+###
 # Base debian build (latest).
 FROM mcr.microsoft.com/vscode/devcontainers/base:debian
 
@@ -13,17 +27,11 @@ ENV SHELL=/usr/bin/zsh
 # Running everything under zsh
 SHELL ["/usr/bin/zsh", "-c"]
 
+# Include Medusa
+COPY --chown=root:root --from=medusa /usr/local/bin/medusa /usr/local/bin/medusa
+
 # Dropping privileges
 USER vscode
-
-# Install golang's latest version through asdf
-RUN git clone https://github.com/asdf-vm/asdf.git $HOME/.asdf --branch v0.14.0 \
-    && echo '. $HOME/.asdf/asdf.sh' >> $HOME/.zshrc \
-    && echo 'fpath=(${ASDF_DIR}/completions $fpath)' >> $HOME/.zshrc \
-    && echo 'autoload -Uz compinit && compinit' >> $HOME/.zshrc \
-    && . $HOME/.asdf/asdf.sh \
-    && asdf plugin add golang \
-    && asdf install golang latest
 
 # Install rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && source $HOME/.cargo/env
@@ -37,7 +45,7 @@ RUN pipx install solc-select
 # # Install slither
 RUN pipx install slither-analyzer
 
-# # install Medusa (crytic-compile)
+# # Install crytic-compile
 RUN pipx install crytic-compile
 
 # ## Foundry framework


### PR DESCRIPTION
In the current version of the `Dockerfile`, `medusa` is not being installed.

This PR installs `medusa` using a multi-stage build. This way, the `go` installation can be removed from the main container.