### PR TITLE
Fix cyfrinup link

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,7 +103,7 @@ RUN curl -fsSL https://foundry.paradigm.xyz | zsh
 RUN foundryup
 
 ## Aderyn
-RUN curl -fsSL https://raw.githubusercontent.com/Cyfrin/aderyn/dev/cyfrinup/install | zsh
+RUN curl -fsSL https://raw.githubusercontent.com/Cyfrin/up/main/install | zsh
 RUN cyfrinup
 
 ## Halmos


### PR DESCRIPTION
curl https://raw.githubusercontent.com/Cyfrin/aderyn/dev/cyfrinup/install

returns a 404 link. 

Repository has moved: https://github.com/Cyfrin/up

correct link is https://raw.githubusercontent.com/Cyfrin/up/main/install
