### PR TITLE
fix: correct UV_LOCAL_BIN path and enhance auditor tooling

### DIFF
--- a/.devcontainer/airgapped/Dockerfile
+++ b/.devcontainer/airgapped/Dockerfile
@@ -59,7 +59,7 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # Update PATH environment for tool access
 # Configure paths for Python, Node.js, and other tools
-ENV UV_LOCAL_BIN=$HOME/.cargo/bin
+ENV UV_LOCAL_BIN=$HOME/.local/bin
 ENV USR_LOCAL_BIN=/usr/local/bin
 ENV LOCAL_BIN=${HOME}/.local/bin
 ENV PNPM_HOME=${HOME}/.local/share/pnpm

--- a/.devcontainer/auditor/Dockerfile
+++ b/.devcontainer/auditor/Dockerfile
@@ -61,7 +61,7 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # Update PATH environment for tool access
 # Configure paths for Python, Node.js, and other tools
-ENV UV_LOCAL_BIN=$HOME/.cargo/bin
+ENV UV_LOCAL_BIN=$HOME/.local/bin
 ENV USR_LOCAL_BIN=/usr/local/bin
 ENV LOCAL_BIN=${HOME}/.local/bin
 ENV PNPM_HOME=${HOME}/.local/share/pnpm
@@ -114,6 +114,7 @@ RUN foundryup
 # Focused on core auditing tools: slither, mythril, crytic-compile
 RUN uv tool install slither-analyzer && \
     uv tool install mythril && \
+    uv tool install slither-lsp && \
     uv tool install crytic-compile 
 
 # Install Hardhat and Solhint for Ethereum development

--- a/.devcontainer/auditor/devcontainer.json
+++ b/.devcontainer/auditor/devcontainer.json
@@ -35,7 +35,7 @@
                 "tintinweb.graphviz-interactive-preview",
                 "NomicFoundation.hardhat-solidity",
                 "Olympixai.olympix",
-                "trailofbits.contract-explorer",
+                "trailofbits.slither-vscode",
                 "tintinweb.chonky"                            // Chonky Agent
             ],
             // VS Code settings optimized for auditing workflows

--- a/.devcontainer/hardened/Dockerfile
+++ b/.devcontainer/hardened/Dockerfile
@@ -59,7 +59,7 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # Update PATH environment for tool access
 # Configure paths for Python, Node.js, and other tools
-ENV UV_LOCAL_BIN=$HOME/.cargo/bin
+ENV UV_LOCAL_BIN=$HOME/.local/bin
 ENV USR_LOCAL_BIN=/usr/local/bin
 ENV LOCAL_BIN=${HOME}/.local/bin
 ENV PNPM_HOME=${HOME}/.local/share/pnpm

--- a/.devcontainer/minimal/Dockerfile
+++ b/.devcontainer/minimal/Dockerfile
@@ -64,7 +64,7 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # Update PATH environment for tool access
 # Configure paths for Python, Node.js, and other tools
-ENV UV_LOCAL_BIN=$HOME/.cargo/bin
+ENV UV_LOCAL_BIN=$HOME/.local/bin
 ENV USR_LOCAL_BIN=/usr/local/bin
 ENV LOCAL_BIN=${HOME}/.local/bin
 ENV PNPM_HOME=${HOME}/.local/share/pnpm

--- a/.devcontainer/paranoid/Dockerfile
+++ b/.devcontainer/paranoid/Dockerfile
@@ -55,7 +55,7 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # Update PATH environment for tool access
 # Configure paths for Python, Node.js, and other tools
-ENV UV_LOCAL_BIN=$HOME/.cargo/bin
+ENV UV_LOCAL_BIN=$HOME/.local/bin
 ENV USR_LOCAL_BIN=/usr/local/bin
 ENV LOCAL_BIN=${HOME}/.local/bin
 ENV PNPM_HOME=${HOME}/.local/share/pnpm

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ The project supports multiple devcontainer configurations for different use case
 .devcontainer/
 ├── hardened/          # Hardened
 ├── airgapped/         # Enhanced security with flexibility
+├── eth-security-toolbox/ # Based on Trail of Bits's dockerfile
+├── codespaces         # GitHub Codespaces Variant
 ├── auditor/           # Specialized audit environment
 ├── minimal/           # Essential tools only
 └── legacy/            # Complete toolchain (original)
@@ -118,7 +120,7 @@ The project supports multiple devcontainer configurations for different use case
 ## Quick Start
 
 1. **Choose your variant** based on your needs (see above)
-2. **Navigate to the variant directory**: `cd .devcontainer/[variant-name]`
+2. **Navigate to the devcontainer directory**: `cd .devcontainer`
 3. **Open in VS Code**: `code .`
 4. **Reopen in Container**: Select the appropriate devcontainer when prompted
 


### PR DESCRIPTION
- Fix UV_LOCAL_BIN environment variable from ~/.cargo/bin to ~/.local/bin across all devcontainer variants (airgapped, auditor, hardened, minimal, paranoid)
- Add slither-lsp tool installation to auditor variant for enhanced LSP support
- Replace deprecated contract-explorer extension with slither-vscode in auditor configuration
- Update README to reflect new eth-security-toolbox and codespaces variants
- Simplify Quick Start navigation instructions

closes #21 